### PR TITLE
Use apt-get dist-upgrade instead of just upgrade

### DIFF
--- a/lib/actions
+++ b/lib/actions
@@ -145,7 +145,10 @@ elif [ "${DISTRO}" == "ubuntu12.04" ]; then
   apt-get update > /dev/null
   if [ "$(/usr/lib/update-notifier/apt-check 2>&1|cut -d';' -f1)" != "0" ]; then
     echo "Updating..."
-    apt-get -y upgrade
+    apt-get -y dist-upgrade
+    if [ ${?} -ne 0 ]; then
+      exit ${?}
+    fi
   else
     echo "No updates needed"
   fi


### PR DESCRIPTION
As postgresql was requesting to install some dependencies for an update, apt-get update was not enough.

We can start using dist-upgrade as in the end our systems are locked to use 12.04.

Tested at https://jenkins.juliogonzalez.es/job/tds_fdw-update-jails/178/
