### PR TITLE
Remove Ubuntu16.04, add Ubuntu 20.04, and make the code more generic

### DIFF
--- a/ci
+++ b/ci
@@ -14,7 +14,7 @@ LANG=en_EN
 SCRIPT=$(basename ${0})
 
 # Supported distributions and PostgreSQL versions
-SUPPORTEDDISTROS="centos7 ubuntu16.04 ubuntu18.04"
+SUPPORTEDDISTROS="centos7 ubuntu18.04 ubuntu20.04"
 SUPPORTEDPGVERS="9.5 9.6 10 11 12 13"
 
 # read the options
@@ -119,16 +119,10 @@ export SHORTDISTRO="$(echo ${DISTRO}|tr -d '.')"
 # End setting variables to be passed to the jail
 export POSTGRESSCHEMA="postgresql${SHORTVER_FULL/-}_${SHORTDISTRO}_test"
 export MSSQLSCHEMA="${POSTGRESSCHEMA}"
-if [ "${DISTRO}" == "centos6" ]; then
+if [[ "${DISTRO}" =~ ^centos[0-9]$ ]]; then
   export PGBIN_PATH="/usr/pgsql-${PG_VER}/bin"
   export POSTGRESPORT=$(sed -n 's/^port = \([0-9]*\).*/\1/p' /var/lib/pgsql/${PG_VER}/data/postgresql.conf)
-elif [ "${DISTRO}" == "centos7" ]; then
-  export PGBIN_PATH="/usr/pgsql-${PG_VER}/bin"
-  export POSTGRESPORT=$(sed -n 's/^port = \([0-9]*\).*/\1/p' /var/lib/pgsql/${PG_VER}/data/postgresql.conf)
-elif [ "${DISTRO}" == "ubuntu16.04" ]; then
-  export PGBIN_PATH="/usr/lib/postgresql/${PG_VER}/bin"
-  export POSTGRESPORT=$(sed -n 's/^port = \([0-9]*\).*/\1/p' /etc/postgresql/${PG_VER}/main/postgresql.conf)
-elif [ "${DISTRO}" == "ubuntu18.04" ]; then
+elif [[ "${DISTRO}" =~ ^ubuntu[0-9]{2}.[0-9]{2}$ ]]; then
   export PGBIN_PATH="/usr/lib/postgresql/${PG_VER}/bin"
   export POSTGRESPORT=$(sed -n 's/^port = \([0-9]*\).*/\1/p' /etc/postgresql/${PG_VER}/main/postgresql.conf)
 fi

--- a/lib/actions
+++ b/lib/actions
@@ -4,13 +4,15 @@ get_info() {
   echo -e "${PURPLEBOLD}=================================================================================${COLORCLEAR}"
   echo -e "${PURPLEBOLD}                                    INFO                                         ${COLORCLEAR}"
   echo -e "${PURPLEBOLD}=================================================================================${COLORCLEAR}"
-  if [ "${DISTRO}" == "centos6" ]; then
+  if [[ "${DISTRO}" =~ ^centos[0-9]$ ]]; then
     INFO_RELEASE="$(cat /etc/redhat-release)"
     PKG_POSTGRES_SERVER_VER=$(rpm -qa postgresql${SHORTVER}-server|rev|cut -d '.' -f2,3-|cut -d '-' -f 1,2|rev)
     PKG_POSTGRES_DEV_VER=$(rpm -qa postgresql${SHORTVER}-devel|rev|cut -d '.' -f2,3-|cut -d '-' -f 1,2|rev)
     PKG_FREETDS_VER=$(rpm -qa freetds|rev|cut -d '.' -f2,3-|cut -d '-' -f 1,2|rev)
     PKG_FREETDS_DEV_VER=$(rpm -qa freetds-devel|rev|cut -d '.' -f2,3-|cut -d '-' -f 1,2|rev)
-  elif [ "${DISTRO}" == "ubuntu16.04" ]; then
+    LLVM_VER=$(rpm -qa llvm[0-9].[0-9]|rev|cut -d '.' -f2,3-|cut -d '-' -f 1,2|rev)
+    CLANG_VER=$(rpm -qa llvm-toolset-[0-9]-clang|rev|cut -d '.' -f2,3-|cut -d '-' -f 1,2|rev)
+  elif [[ "${DISTRO}" =~ ^ubuntu[0-9]{2}.[0-9]{2}$ ]]; then
     INFO_RELEASE="$(. /etc/os-release; echo ${VERSION})"
     PKG_POSTGRES_SERVER_VER=$(dpkg -s postgresql-${PG_VER}|grep '^Version:'|cut -d ' ' -f 2)
     PKG_POSTGRES_DEV_VER=$(dpkg -s postgresql-server-dev-${PG_VER}|grep '^Version:'|cut -d ' ' -f 2)


### PR DESCRIPTION
In preparation to make the test framework compatible with Python3 (the Ubuntu 20.04 docker images will use python3 instead of python2)

Related: https://github.com/tds-fdw/tds_fdw/issues/284