### PR TITLE
Add PostgreSQL 18, remove 12 and older, remove Ubuntu 20.04

### DIFF
--- a/ci
+++ b/ci
@@ -14,8 +14,8 @@ LANG=en_EN
 SCRIPT=$(basename ${0})
 
 # Supported distributions and PostgreSQL versions
-SUPPORTEDDISTROS="rockylinux8 ubuntu20.04 ubuntu24.04 opensuseleap15.6"
-SUPPORTEDPGVERS="9.6 10 11 12 13 14 15 16 17"
+SUPPORTEDDISTROS="rockylinux8 ubuntu24.04 opensuseleap15.6"
+SUPPORTEDPGVERS="13 14 15 16 17 18-testing"
 
 # Ignored combinations, will exit without errors so the CI does not fail
 IGNOREDCOMBINATIONS=""


### PR DESCRIPTION
Related: https://github.com/tds-fdw/tds_fdw/issues/384

Tested at https://jenkins.juliogonzalez.es/view/tds_fdw-jobs/job/tds_fdw-build-free/, failures for PostgreSQL18 are normal and being discussed at https://github.com/tds-fdw/tds_fdw/issues/384

Depends on https://github.com/tds-fdw/ci-setup/pull/12 being merged and building containers first.