### PR TITLE
Replace PostgreSQL 18-testing with 18 (stable)

### DIFF
--- a/ci
+++ b/ci
@@ -15,7 +15,7 @@ SCRIPT=$(basename ${0})
 
 # Supported distributions and PostgreSQL versions
 SUPPORTEDDISTROS="rockylinux8 ubuntu24.04 opensuseleap15.6"
-SUPPORTEDPGVERS="13 14 15 16 17 18-testing"
+SUPPORTEDPGVERS="13 14 15 16 17 18"
 
 # Ignored combinations, will exit without errors so the CI does not fail
 IGNOREDCOMBINATIONS=""


### PR DESCRIPTION
Follow-up https://github.com/juliogonzalez/docker-postgresql/pull/12 and https://github.com/tds-fdw/ci-setup/pull/14

PostgreSQL 18 is finally released.