### PR TITLE
Add new options from upstream PR #407

### DIFF
--- a/ci
+++ b/ci
@@ -32,24 +32,26 @@ eval set -- "${ARGS}"
 # extract options and their arguments into variables
 while true ; do
   case "${1}" in
-    -h|--help)              help "${SUPPORTEDPGVERS}" "${SUPPORTEDDISTROS}"; exit 1;;
-    --action)               ACTION="${2}"; shift 2;;
-    --distro)               export DISTRO="${2}"; shift 2;;
-    --pgver)                export PG_VER="${2}"; shift 2;;
-    --tdsdir)               export TDSDIR="${2}"; shift 2;;
-    --mssqlhost)            export MSSQLHOST="${2}"; shift 2;;
-    --mssqlport)            export MSSQLPORT="${2}"; shift 2;;
-    --mssqldb)              export MSSQLDB="${2}"; shift 2;;
-    --mssqluser)            export MSSQLUSER="${2}"; shift 2;;
-    --mssqlpass)            export MSSQLPASS="${2}"; shift 2;;
-    --postgreshost)         export POSTGRESHOST="${2}"; shift 2;;
-    --postgresport)         export POSTGRESPORT="${2}"; shift 2;;
-    --postgresdb)           export POSTGRESDB="${2}"; shift 2;;
-    --postgresuser)         export POSTGRESUSER="${2}"; shift 2;;
-    --postgrespass)         export POSTGRESPASS="${2}"; shift 2;;
-    --max_retries)          export MAX_RETRIES="${2}"; shift 2;;
-    --wait_sec)             export WAIT_SEC="${2}"; shift 2;;
-    --unattended_debugging) export UNATTENDED_DEBUG="TRUE"; shift 1;;
+    -h|--help)               help "${SUPPORTEDPGVERS}" "${SUPPORTEDDISTROS}"; exit 1;;
+    --action)                ACTION="${2}"; shift 2;;
+    --distro)                export DISTRO="${2}"; shift 2;;
+    --pgver)                 export PG_VER="${2}"; shift 2;;
+    --tdsdir)                export TDSDIR="${2}"; shift 2;;
+    --mssqlhost)             export MSSQLHOST="${2}"; shift 2;;
+    --mssqlport)             export MSSQLPORT="${2}"; shift 2;;
+    --mssqldb)               export MSSQLDB="${2}"; shift 2;;
+    --mssqluser)             export MSSQLUSER="${2}"; shift 2;;
+    --mssqlpass)             export MSSQLPASS="${2}"; shift 2;;
+    --postgreshost)          export POSTGRESHOST="${2}"; shift 2;;
+    --postgresport)          export POSTGRESPORT="${2}"; shift 2;;
+    --postgresdb)            export POSTGRESDB="${2}"; shift 2;;
+    --postgresuser)          export POSTGRESUSER="${2}"; shift 2;;
+    --postgrespass)          export POSTGRESPASS="${2}"; shift 2;;
+    --tds_fdw_msg_handler)   export TDS_FDW_MSG_HANDLER="${2}"; shift 2;;
+    --postgres_min_messages) export POSTGRES_MIN_MESSAGES="${2}"; shift 2;;
+    --max_retries)           export MAX_RETRIES="${2}"; shift 2;;
+    --wait_sec)              export WAIT_SEC="${2}"; shift 2;;
+    --unattended_debugging)  export UNATTENDED_DEBUG="TRUE"; shift 1;;
     --) shift ; break ;;
     *) print_incorrect_syntax; exit 1;;
   esac

--- a/lib/actions
+++ b/lib/actions
@@ -123,7 +123,7 @@ pg_test() {
     UNATTENDED_DEBUGGING="--unattended_debugging"
   fi
   POSTGRESHOST='127.0.0.1'
-  PYTHONUNBUFFERED=True ${PYTHON} ./postgresql-tests.py --mssql_server ${MSSQLHOST} --mssql_port ${MSSQLPORT} --mssql_database tds_fdw_jenkins --mssql_username ${MSSQLUSER} --mssql_password ${MSSQLPASS} --mssql_schema ${MSSQLSCHEMA} --postgres_server ${POSTGRESHOST} --postgres_port ${POSTGRESPORT} --postgres_database ${POSTGRESDB} --postgres_username ${POSTGRESUSER} --postgres_password ${POSTGRESPASS} --postgres_schema ${POSTGRESSCHEMA} --azure ${UNATTENDED_DEBUGGING}
+  PYTHONUNBUFFERED=True ${PYTHON} ./postgresql-tests.py --mssql_server ${MSSQLHOST} --mssql_port ${MSSQLPORT} --mssql_database tds_fdw_jenkins --mssql_username ${MSSQLUSER} --mssql_password ${MSSQLPASS} --mssql_schema ${MSSQLSCHEMA} --postgres_server ${POSTGRESHOST} --postgres_port ${POSTGRESPORT} --postgres_database ${POSTGRESDB} --postgres_username ${POSTGRESUSER} --postgres_password ${POSTGRESPASS} --postgres_schema ${POSTGRESSCHEMA} --tds_fdw_msg_handler="${TDS_FDW_MSG_HANDLER}" --postgres_min_messages="${POSTGRES_MIN_MESSAGES}" --azure ${UNATTENDED_DEBUGGING}
 }
 
 pg_dropdb() {


### PR DESCRIPTION
https://github.com/tds-fdw/tds_fdw/issues/407 introduced more parameters for PostgreSQL tests.

This PR enables support for them, so we can call them from the CI.