### PR TITLE
Remove PostgreSQL13, add 19-testing, switch Rocky Linux 8 to 9

### DIFF
--- a/ci
+++ b/ci
@@ -14,8 +14,8 @@ LANG=en_EN
 SCRIPT=$(basename ${0})
 
 # Supported distributions and PostgreSQL versions
-SUPPORTEDDISTROS="rockylinux8 ubuntu24.04 opensuseleap16.0"
-SUPPORTEDPGVERS="13 14 15 16 17 18"
+SUPPORTEDDISTROS="rockylinux9 ubuntu24.04 opensuseleap16.0"
+SUPPORTEDPGVERS="14 15 16 17 18 19-testing"
 
 # Ignored combinations, will exit without errors so the CI does not fail
 IGNOREDCOMBINATIONS=""


### PR DESCRIPTION
As per https://yum.postgresql.org/, Rocky Linux 8 and similar will not get PostgreSQL19

Required for testing https://github.com/tds-fdw/tds_fdw/pull/417 / https://github.com/tds-fdw/tds_fdw/pull/422